### PR TITLE
Raw to kerberos

### DIFF
--- a/sniffer.py
+++ b/sniffer.py
@@ -1,24 +1,20 @@
 from argparse import ArgumentParser
 from scapy.layers.kerberos import Kerberos
-from scapy.packet import Packet, Raw
+from scapy.packet import Packet
 from scapy.sendrecv import sniff
 
 
 def process_pack(pack: Packet):
-    raw_content = pack[Raw]
-    try:
-        krb_layer = Kerberos(raw_content)
-        # TODO что-то делать с kerberos-данными при помощи ML
-        return krb_layer.summary()
-    # если не получилось спарсить в kerberos-пакет, то считаем, что это не kerberos-пакет, и ничего не делаем
-    except Exception as e:
-        return e
+    krb_layer = pack[Kerberos]
+    # TODO что-то делать с kerberos-данными при помощи ML
+    # пока просто выводим тип kerberos-сообщения
+    return krb_layer.summary()
 
 
 if __name__ == '__main__':
     parser = ArgumentParser(description='Детектор атаки Kerberoasting')
     parser.add_argument('--iface', required=False, help='Отслеживаемый интерфейс')
     args = parser.parse_args()
-    sniff(lfilter=lambda pack: pack.haslayer(Raw),
+    sniff(lfilter=lambda pack: pack.haslayer(Kerberos),
           prn=lambda pack: process_pack(pack),
           iface=args.iface)


### PR DESCRIPTION
Сначала думал, что для kerberos не происходит автоматическое преобразование из "сырых" данных. Но, прогнав сниффер на реальном kerberos-сервере, увидел, что происходит.

Все, что поменялось:

1. добавилось немного синтаксического сахара из scapy для получения сообщений разного уровня
2. изменено выводимое при каждом kerberos-пакете сообщение (теперь вместо всех слоев будет выводится тип kerberos-пакета)
3. изменен аргумент, определяющий, какой интерфейс будет "прослушан" сниффером